### PR TITLE
Fix/resize modals and popups

### DIFF
--- a/src/Components/AboutUs/_aboutus.scss
+++ b/src/Components/AboutUs/_aboutus.scss
@@ -104,6 +104,6 @@
   }
 
   .team-grid {
-  width: 88%;
-}
+    width: 88%;
+  }
 }

--- a/src/Components/AddContact/AddContact.js
+++ b/src/Components/AddContact/AddContact.js
@@ -18,18 +18,19 @@ const CREATE_CONTACT = gql`
 `
 
 function AddContact({ user }) {
-  const [valid, setValidCheck] = useState(false)
-  const [verify, setPhoneVerify] = useState(false)
-  const [firstName, setFirst] = useState('')
-  const [lastName, setLast] = useState('')
-  const [countryCode, setCountry] = useState('')
-  const [areaCode, setArea] = useState('')
-  const [phoneNumber, setPhone] = useState('')
-  const [createContact, { loading: mutationLoading, error: mutationError, data }] = useMutation(CREATE_CONTACT)
+  const [valid, setValidCheck] = useState(false);
+  const [verify, setPhoneVerify] = useState(false);
+  const [firstName, setFirst] = useState('');
+  const [lastName, setLast] = useState('');
+  const [countryCode, setCountry] = useState('');
+  const [areaCode, setArea] = useState('');
+  const [phoneNumber, setPhone] = useState('');
+  // const [createContact, { loading: mutationLoading, error: mutationError, data }] = useMutation(CREATE_CONTACT);
+  const [createContact, { loading: mutationLoading, error: mutationError }] = useMutation(CREATE_CONTACT);
 
   function addContact(e) {
     e.preventDefault();
-    if (!firstName || !lastName || !countryCode || !areaCode || !phoneNumber){
+    if (!firstName || !lastName || !countryCode || !areaCode || !phoneNumber) {
       return setValidCheck(true);
     }
     if (checkPhoneNum()){
@@ -47,10 +48,10 @@ function AddContact({ user }) {
     if (countryCode.length === 0) {
       setPhoneVerify(true);
       return true;
-    } else if(areaCode.length !== 3) {
+    } else if (areaCode.length !== 3) {
       setPhoneVerify(true);
       return true;
-    } else if(phoneNumber.length !== 7) {
+    } else if (phoneNumber.length !== 7) {
       setPhoneVerify(true);
       return true;
     } else {
@@ -67,9 +68,9 @@ function AddContact({ user }) {
     setPhone('');
   }
 
-  function modifyNumberInput(event) {
-    setPhone(toString(event.target.value));
-  }
+  // function modifyNumberInput(event) {
+  //   setPhone(toString(event.target.value));
+  // }
 
   return (
     <section className='add-contact'>

--- a/src/Components/AddTime/AddTime.js
+++ b/src/Components/AddTime/AddTime.js
@@ -48,17 +48,6 @@ function AddTime( { setExtension, setEmergency, setEtaSeconds, modalIsOpen, clos
     closeModal();
   }
 
-  const customStyles = {
-    control: (base) => ({
-      ...base,
-      height: 20,
-      minHeight: 35,
-      backgroundColor: '#c6fc80bd',
-      paddingLeft: '3px',
-      paddingBottom: '3px'
-    })
-  };
-
   const renderTime = (unit, time) => {
     return (
       <div className='backup-timer'>
@@ -116,7 +105,6 @@ function AddTime( { setExtension, setEmergency, setEtaSeconds, modalIsOpen, clos
               handleExtension(selectedTime)
             }}
             options={extendedTimeOptions}
-            styles={customStyles}
           />
         </section>
       </div>

--- a/src/Components/AddTime/AddTime.js
+++ b/src/Components/AddTime/AddTime.js
@@ -23,6 +23,7 @@ function AddTime( { setExtension, setEmergency, setEtaSeconds, modalIsOpen, clos
   useEffect(() => {
     window.addEventListener("resize", updateDimensions);
     return () => window.removeEventListener("resize", updateDimensions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const updateDimensions = () => {
@@ -47,9 +48,20 @@ function AddTime( { setExtension, setEmergency, setEtaSeconds, modalIsOpen, clos
     closeModal();
   }
 
+  const customStyles = {
+    control: (base) => ({
+      ...base,
+      height: 20,
+      minHeight: 35,
+      backgroundColor: '#c6fc80bd',
+      paddingLeft: '3px',
+      paddingBottom: '3px'
+    })
+  };
+
   const renderTime = (unit, time) => {
     return (
-      <div className='timer-wrapper'>
+      <div className='backup-timer'>
         <div className='time-amt'>{Math.floor(time)}</div>
         <div className='time-unit'>{unit}</div>
       </div>
@@ -104,6 +116,7 @@ function AddTime( { setExtension, setEmergency, setEtaSeconds, modalIsOpen, clos
               handleExtension(selectedTime)
             }}
             options={extendedTimeOptions}
+            styles={customStyles}
           />
         </section>
       </div>

--- a/src/Components/AddTime/_addtime.scss
+++ b/src/Components/AddTime/_addtime.scss
@@ -68,7 +68,13 @@
 }
 
 @media screen and (max-width: 1025px) {
+  .end-trip-modal-btn {
+    height: 3em;
+  }
 
+  .add-time-response {
+    // height: 3em;
+  }
 }
 
 @media screen and (max-width: 930px) {
@@ -129,7 +135,7 @@
 
   .add-time-response {
     height: 30%;
-    justify-content: space-center;
+    justify-content: center;
     padding: 0;
   }
 

--- a/src/Components/AddTime/_addtime.scss
+++ b/src/Components/AddTime/_addtime.scss
@@ -22,6 +22,10 @@
   font-size: 1.25vw;
 }
 
+.backup-timer {
+  text-align: center;
+}
+
 .add-time-response {
   display: flex;
   justify-content: space-evenly;
@@ -32,7 +36,6 @@
   // END TRIP button size
   a {
     width: 45%;
-    height: 78%;
   }
 }
 
@@ -56,7 +59,7 @@
   display: flex;
   padding: 0;
   flex-direction: column;
-  background-color: rgba(198, 252, 128, 0.74);
+  background-color: #c6fc80bd;
   font-size: 1vw;
   border: 1px solid rgba(158, 136, 136, 0.616);
   border-radius: 5px;
@@ -112,20 +115,34 @@
 
 @media screen and (max-width: 376px) {
   .timeout-message {
-    font-size: 1.3rem;
+    font-size: 1.1rem;
   }
 
   .warning-message {
-    font-size: 1vw;
+    text-align: center;
+    font-size: 0.9rem;
+    margin-bottom: 0.25em;
+  }
+
+  .backup-timer {
+    font-size: 0.8rem;
+  }
+
+  .add-time-response {
+    height: 30%;
+    justify-content: space-center;
+    padding: 0;
   }
 
   .end-trip-modal-btn {
-    font-size: 1em;
+    height: 3em;
+    font-size: 0.8em;
     letter-spacing: 0;
   }
 
   .extend-time {
-    font-size: .4em;
+    font-size: 0.8em;
     letter-spacing: 0;
+    margin: 0;
   }
 }

--- a/src/Components/AddTime/_addtime.scss
+++ b/src/Components/AddTime/_addtime.scss
@@ -68,7 +68,13 @@
 }
 
 @media screen and (max-width: 930px) {
+  .timeout-message {
+    font-size: 1.5rem;
+  }
 
+  .warning-message {
+    font-size: 0.75em;
+  }
 }
 
 @media screen and (max-width: 651px) {

--- a/src/Components/AddTime/_addtime.scss
+++ b/src/Components/AddTime/_addtime.scss
@@ -35,6 +35,7 @@
 
   // END TRIP button size
   a {
+    height: 3.5em;
     width: 45%;
   }
 }
@@ -103,13 +104,11 @@
 
   .end-trip-modal-btn {
     font-size: 0.75em;
-    letter-spacing: 0;
   }
 
   .extend-time {
     width: 60%;
     font-size: 0.5em;
-    letter-spacing: 0;
   }
 }
 
@@ -137,12 +136,11 @@
   .end-trip-modal-btn {
     height: 3em;
     font-size: 0.8em;
-    letter-spacing: 0;
+    letter-spacing: 3px;
   }
 
   .extend-time {
-    font-size: 0.8em;
-    letter-spacing: 0;
+    font-size: 0.7em;
     margin: 0;
   }
 }

--- a/src/Components/AddTime/jsxStyles/dropdownStyles.js
+++ b/src/Components/AddTime/jsxStyles/dropdownStyles.js
@@ -1,8 +1,10 @@
 const addTimeDropdownStyles = {
-  control: () => ({
+  control: (base) => ({
+    ...base,
+    height: 20,
+    minHeight: 35,
+    backgroundColor: '#c6fc80bd',
     display: 'flex',
-    minHeight: '30px',
-    height: '55px',
   }),
   input: () => ({
     color: 'transparent',
@@ -12,7 +14,6 @@ const addTimeDropdownStyles = {
       ...defaultStyles,
       alignSelf: 'center',
       justifySelf: 'center',
-      fontSize: '1.5em',
       textJustify: 'center',
       marginLeft: '4%',
       letterSpacing: '3px',

--- a/src/Components/AddTime/jsxStyles/dropdownStyles.js
+++ b/src/Components/AddTime/jsxStyles/dropdownStyles.js
@@ -1,7 +1,6 @@
 const addTimeDropdownStyles = {
-  control: (base) => ({
-    ...base,
-    height: 20,
+  control: () => ({
+    height: 30,
     minHeight: 35,
     backgroundColor: '#c6fc80bd',
     display: 'flex',

--- a/src/Components/AddTime/jsxStyles/mediaQueries.js
+++ b/src/Components/AddTime/jsxStyles/mediaQueries.js
@@ -1,26 +1,27 @@
 export function getAddTimeModalWidth(width) {
   if (width < 376) {
     return '80%';
-  } if (width < 651) {
+  } else if (width < 651) {
     return '70%';
-  } if (width < 1025)  {
-    return '70%';
+  } else if (width < 930) {
+    return '60%';
+  } else if (width < 1025)  {
+    return '50%';
   } else {
-    return '45%';
+    return '50%';
   }
 }
 
 export function getExtendedTimerWidth(width) {
   if (width < 376) {
     return 145;
-  } 
-  if (width < 651) {
+  } else if (width < 651) {
     return 100;
-  } 
-  if (width < 1025)  {
-    return 250;
-  } 
-  else {
+  } else if (width < 930) {
+    return 150;
+  } else if (width < 1025)  {
     return 200;
+  } else {
+    return 180;
   }
 }

--- a/src/Components/AddTime/jsxStyles/mediaQueries.js
+++ b/src/Components/AddTime/jsxStyles/mediaQueries.js
@@ -14,7 +14,7 @@ export function getAddTimeModalWidth(width) {
 
 export function getExtendedTimerWidth(width) {
   if (width < 376) {
-    return 145;
+    return 80;
   } else if (width < 651) {
     return 100;
   } else if (width < 930) {

--- a/src/Components/AddTime/jsxStyles/mediaQueries.js
+++ b/src/Components/AddTime/jsxStyles/mediaQueries.js
@@ -20,7 +20,7 @@ export function getExtendedTimerWidth(width) {
   } else if (width < 930) {
     return 150;
   } else if (width < 1025)  {
-    return 200;
+    return 160;
   } else {
     return 180;
   }

--- a/src/Components/Alert/Alert.js
+++ b/src/Components/Alert/Alert.js
@@ -14,6 +14,7 @@ function Alert({ setEmergency, modalIsOpen, closeModal }) {
   useEffect(() => {
     window.addEventListener("resize", updateDimensions);
     return () => window.removeEventListener("resize", updateDimensions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   
   const updateDimensions = () => {

--- a/src/Components/Alert/_alert.scss
+++ b/src/Components/Alert/_alert.scss
@@ -7,6 +7,7 @@
   background-color: rgb(223, 74, 74);
   font-family: $roboto;
   font-weight: 500;
+  padding-bottom: 0.5em;
 }
 
 .alert-nav {
@@ -81,6 +82,6 @@
     font-size: 2rem;
   }
   .alert-message {
-    font-size: 1.15rem;
+    font-size: 1rem;
   }
 }

--- a/src/Components/Alert/_alert.scss
+++ b/src/Components/Alert/_alert.scss
@@ -57,6 +57,16 @@
   text-shadow: 0 1px 2px rgb(37, 34, 34);
 }
 
+@media screen and (max-width: 1025px) {
+  .alert-title {
+    font-size: 2.5rem;
+  }
+
+  .alert-message {
+    font-size: 1.5rem;
+  }
+}
+
 @media screen and (max-width: 930px) {
   .alert-title {
     font-size: 2.3rem;

--- a/src/Components/Alert/_alert.scss
+++ b/src/Components/Alert/_alert.scss
@@ -56,19 +56,29 @@
   text-shadow: 0 1px 2px rgb(37, 34, 34);
 }
 
-@media screen and (max-width: 651px) {
+@media screen and (max-width: 930px) {
   .alert-title {
-    font-size: 2.5rem;
+    font-size: 2.3rem;
   }
 
   .alert-message {
-    font-size: 1.6rem;
+    font-size: 1.5rem;
+  }
+}
+
+@media screen and (max-width: 651px) {
+  .alert-title {
+    font-size: 2rem;
+  }
+
+  .alert-message {
+    font-size: 1.3rem;
   }
 }
 
 @media screen and (max-width: 376px) {
   .alert-title {
-    font-size: 2.0rem;
+    font-size: 2rem;
   }
   .alert-message {
     font-size: 1.15rem;

--- a/src/Components/Alert/jsxStyles/mediaQueries.js
+++ b/src/Components/Alert/jsxStyles/mediaQueries.js
@@ -1,9 +1,9 @@
 export default function getAlertWidth(width) {
   if (width < 376) {
     return '80%';
-  } if (width < 651) {
+  } else if (width < 651) {
     return '70%';
-  } if (width < 1025)  {
+  } else if (width < 1025)  {
     return '70%';
   } else {
     return '50%';

--- a/src/Components/App/_app.scss
+++ b/src/Components/App/_app.scss
@@ -20,17 +20,17 @@ body,
   max-height: 100%;
   background-color: rgba(171, 250, 202, 0.664);
   font-family: $roboto;
-
 }
 
 .mm-popup__box {
-  width: 350px;
+  width: 375px;
   position: fixed;
-  top: 30%;
+  top: 35%;
   left: 50%;
-  margin-left: -175px;
-  background-color: rgba(166, 244, 196, 0.664);
-  box-shadow: 0px 5px 20px 0px rgba(126,137,140,0.20);
+  margin-left: -205px;
+  padding: 1em;
+  background-color: rgba(141, 196, 241, 0.966);
+  box-shadow: $shadow-heavy;
   border-radius: 5px;
   border: 3px solid #395148;
   color: #395148;
@@ -56,11 +56,13 @@ body,
   text-align: center;
   padding: 20px;
   line-height: 1.4;
-  font-size: 20px;
-  color: #395148;
+  font-size: 23px;
+  color: rgb(17, 17, 22);
   //background: rgba(166, 244, 196, 0.664);
   position: relative;
   z-index: 2;
+  white-space: pre-wrap;
+  text-shadow: 0 2px 2px rgb(226, 235, 243);
 }
 
 .mm-popup__box__body p {
@@ -69,7 +71,7 @@ body,
 
 .mm-popup__box__footer {
   overflow: hidden;
-  padding: 0px 20px 20px;
+  padding: 0px 10px 10px;
 }
 
 .mm-popup__box__footer__right-space {
@@ -81,4 +83,9 @@ body,
   height: 40px;
   width: 45px;
   border: 3px solid #395148;
+}
+
+.mm-popup__close {
+  outline: none;
+  border: none;
 }

--- a/src/Components/App/_app.scss
+++ b/src/Components/App/_app.scss
@@ -91,3 +91,14 @@ body,
   outline: none;
   border: none;
 }
+
+@media screen and (max-width: 376px) {
+  .mm-popup__box {
+    width: 60%;
+    height: 30%;
+  }
+
+  .mm-popup__box__body {
+    font-size: 1.2rem;
+  }
+}

--- a/src/Components/App/_app.scss
+++ b/src/Components/App/_app.scss
@@ -92,13 +92,45 @@ body,
   border: none;
 }
 
-@media screen and (max-width: 376px) {
+@media screen and (max-width: 1025px) {
+  .mm-popup__box {
+    width: 50%;
+    height: 25%;
+  }
+
+}
+
+@media screen and (max-width: 930px) {
   .mm-popup__box {
     width: 60%;
-    height: 30%;
+    height: 25%;
   }
 
   .mm-popup__box__body {
+    font-size: 1.3rem;
+  }
+}
+
+@media screen and (max-width: 651px) {
+  .mm-popup__box {
+    width: 60%;
+    height: 32%;
+  }
+  .mm-popup__box__body {
     font-size: 1.2rem;
+  }
+}
+
+@media screen and (max-width: 376px) {
+  .mm-popup__box {
+    width: 60%;
+    height: 32%;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  .mm-popup__box {
+    width: 60%;
+    height: 35%;
   }
 }

--- a/src/Components/App/_app.scss
+++ b/src/Components/App/_app.scss
@@ -23,11 +23,13 @@ body,
 }
 
 .mm-popup__box {
-  width: 375px;
+  width: 30%;
+  height: 25%;
   position: fixed;
-  top: 35%;
+  top: 50%;
   left: 50%;
-  margin-left: -205px;
+  transform: translate(-50%, -50%);
+  margin-right: -50%;
   padding: 1em;
   background-color: rgba(141, 196, 241, 0.966);
   box-shadow: $shadow-heavy;
@@ -53,10 +55,10 @@ body,
 }
 
 .mm-popup__box__body {
+  font-size: 1.4rem;
   text-align: center;
   padding: 20px;
   line-height: 1.4;
-  font-size: 23px;
   color: rgb(17, 17, 22);
   //background: rgba(166, 244, 196, 0.664);
   position: relative;

--- a/src/Components/CurrentTrip/CurrentTrip.js
+++ b/src/Components/CurrentTrip/CurrentTrip.js
@@ -77,6 +77,7 @@ function CurrentTrip({ user, eta, contact, tripIsActive, setTripIsActive }) {
       setExtensionModalIsOpen(false);
       setEtaSeconds(null);
       setExtension(0);
+      // THIS IS CAUSING THE CONSOLE 'MEMORY LEAK' ERROR
       setTripEnded(true);
       TripNotCompleteMessage(user, contact)
     }

--- a/src/Components/CurrentTrip/CurrentTrip.js
+++ b/src/Components/CurrentTrip/CurrentTrip.js
@@ -53,6 +53,7 @@ function CurrentTrip({ user, eta, contact, tripIsActive, setTripIsActive }) {
       setExtension(0);
       setEtaSeconds(null);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hoursActive, minutesActive, secondsActive]);
 
   useEffect(() => {
@@ -85,6 +86,7 @@ function CurrentTrip({ user, eta, contact, tripIsActive, setTripIsActive }) {
   useEffect(() => {
       window.addEventListener("resize", updateDimensions);
       return () => window.removeEventListener("resize", updateDimensions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const updateDimensions = () => {

--- a/src/Components/CurrentTrip/CurrentTrip.js
+++ b/src/Components/CurrentTrip/CurrentTrip.js
@@ -107,7 +107,7 @@ function CurrentTrip({ user, eta, contact, tripIsActive, setTripIsActive }) {
     setTripEnded(true);
     setTripIsActive(false);
     setExtensionModalIsOpen(false);
-    TripCompleteMessage(contact, user)
+    TripCompleteMessage(contact, user);
   }
 
   function closeExtensionModal() {

--- a/src/Components/CurrentTrip/_currenttrip.scss
+++ b/src/Components/CurrentTrip/_currenttrip.scss
@@ -169,3 +169,11 @@
 
   }
 }
+
+@media screen and (max-width: 321px) {
+  .trip-container {
+    width: 65%;
+    height: 60%;
+    margin: 0.1em;
+  }
+}

--- a/src/Components/CurrentTrip/_currenttrip.scss
+++ b/src/Components/CurrentTrip/_currenttrip.scss
@@ -81,6 +81,22 @@
   }
 }
 
+@media screen and (max-width: 1025px) {
+  .trip-container {
+    width: 80%;
+    height: 50%;
+    margin-top: 2em;
+  }
+
+  .timer-wrapper {
+    font-size: 2.5em;
+  }
+
+  .end-trip-btn {
+    font-size: 2em;
+  }
+}
+
 @media screen and (max-width: 930px) {
   .trip-container {
     width: 70%;
@@ -175,5 +191,9 @@
     width: 65%;
     height: 60%;
     margin: 0.1em;
+  }
+
+  .timer-wrapper {
+    font-size: 1em;
   }
 }

--- a/src/Components/CurrentTrip/mediaQueries.js
+++ b/src/Components/CurrentTrip/mediaQueries.js
@@ -8,7 +8,7 @@ export default function getMainTimerSize(width) {
   } else if (width < 930) {
     return 160;
   } else if (width < 1025)  {
-    return 250;
+    return 200;
   } else {
     return 180;
   }

--- a/src/Components/CurrentTrip/mediaQueries.js
+++ b/src/Components/CurrentTrip/mediaQueries.js
@@ -1,5 +1,7 @@
 export default function getMainTimerSize(width) {
-  if (width < 376) {
+  if (width < 321) {
+    return 90;
+  } else if (width < 376) {
     return 115;
   } else if (width < 651) {
     return 130;

--- a/src/Components/CurrentTrip/mediaQueries.js
+++ b/src/Components/CurrentTrip/mediaQueries.js
@@ -1,17 +1,13 @@
 export default function getMainTimerSize(width) {
   if (width < 376) {
     return 115;
-  } 
-  if (width < 651) {
+  } else if (width < 651) {
     return 130;
-  } 
-  if (width < 930) {
+  } else if (width < 930) {
     return 160;
-  } 
-  if (width < 1025)  {
+  } else if (width < 1025)  {
     return 250;
-  } 
-  else {
+  } else {
     return 180;
   }
 }

--- a/src/Components/Form/Form.js
+++ b/src/Components/Form/Form.js
@@ -24,7 +24,7 @@ function Form({ contacts, handleEtaChange, userInfo, setContact, setTripIsActive
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [valid, setValidCheck] = useState(false);
-  const [query, setQuery] = useState('');
+  // const [query, setQuery] = useState('');
   const [endPoint, setEndPoint] = useState('');
   const [startPoint, setStartPoint] = useState('');
   const [formattedContacts, setFormattedContacts] = useState([]);
@@ -44,6 +44,13 @@ function Form({ contacts, handleEtaChange, userInfo, setContact, setTripIsActive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
+  const customStyles = {
+    control: base => ({
+      ...base,
+      height: 45,
+      minHeight: 35
+    })
+  };
 
   function formatContacts() {
     const formatted = contacts.map(contact => {
@@ -70,17 +77,6 @@ function Form({ contacts, handleEtaChange, userInfo, setContact, setTripIsActive
     // clearForm();
   }
 
-  // function clearForm() {
-  //   setEndPoint('');
-  //   setStartPoint('');
-  //   setQuery('');
-  //   setTravelMode('');
-  //   setSelectedContact('');
-  // }
-
-  // function handleEnter(e) {
-  //   if(e.key === 'Enter')
-  // }
   function openModal() {
     setModalIsOpen(true);
   }
@@ -102,7 +98,7 @@ function Form({ contacts, handleEtaChange, userInfo, setContact, setTripIsActive
       </pre>}
       <Autocomplete
           onPlaceSelected={(place) => setStartPoint(place.formatted_address)}
-          onChange={event => setQuery(event.target.value)}
+          // onChange={event => setQuery(event.target.value)}
           options={{types: ['address']}}
           placeholder='Starting address'
           onKeyPress={(e) => { e.key === 'Enter' && e.preventDefault(); }}
@@ -111,7 +107,7 @@ function Form({ contacts, handleEtaChange, userInfo, setContact, setTripIsActive
       />
       <Autocomplete
           onPlaceSelected={(place) => setEndPoint(place.formatted_address)}
-          onChange={event => setQuery(event.target.value)}
+          // onChange={event => setQuery(event.target.value)}
           options={{types: ['address']}}
           placeholder='Final address'
           onKeyPress={(e) => { e.key === 'Enter' && e.preventDefault(); }}
@@ -126,6 +122,7 @@ function Form({ contacts, handleEtaChange, userInfo, setContact, setTripIsActive
         onChange={setTravelMode}
         onKeyPress={(e) => { e.key === 'Enter' && e.preventDefault(); }}
         options={transportOptions}
+        styles={customStyles}
       />
       <Select
         className='dropdown select-contact'
@@ -135,6 +132,7 @@ function Form({ contacts, handleEtaChange, userInfo, setContact, setTripIsActive
         onChange={setContactForApp}
         onKeyPress={(e) => { e.key === 'Enter' && e.preventDefault(); }}
         options={formattedContacts}
+        styles={customStyles}
       />
       <button onClick={sendTripData} className='submit-trip-btn'>
         SUBMIT TRIP

--- a/src/Components/Form/_form.scss
+++ b/src/Components/Form/_form.scss
@@ -5,7 +5,7 @@
   justify-content: space-evenly;
   height: 45%;
   width: 40%;
-  padding-top: 2em;
+  padding-top: 1em;
   padding-bottom: 1em;
   margin: 4em;
   border-radius: 5px;
@@ -16,7 +16,6 @@
     width: 40%;
     height: 15%;
     padding: 3px;
-    margin: 1.5em auto 0.75em auto;
     border-radius: 5px;
     color: ghostwhite;
     background-color: cornflowerblue;
@@ -44,7 +43,7 @@
   width: 60%;
   height: 8%;
   padding: 5px;
-  margin: 0.5em;
+  margin: 0.25em;
   border-radius: 5px;
   font-size: 1em;
 }
@@ -53,7 +52,7 @@
   display: flex;
   flex-direction: column;
   width: 65%;
-  padding: 0.5em;
+  padding: 5px;
   color: black;
 }
 
@@ -65,13 +64,11 @@
   }
 
   .location-input {
-    height: 6%;
     font-size: 1.25em;
   }
 
   .dropdown {
     width: 65%;
-    padding: 0.5em;
     font-size: 1.25em;
   }
 
@@ -92,25 +89,24 @@
   }
 
   .dropdown {
-    padding: 0.5em;
     font-size: 1.25em;
   }
 }
 
 @media screen and (max-width: 651px) {
   .trip-form {
-    width: 70%;
+    width: 75%;
   }
 
   .location-input {
-    width: 69%;
+    width: 72%;
     height: 7%;
     margin: 0.1em;
     font-size: 1em;
   }
 
   .dropdown {
-    width: 81%;
+    width: 78%;
     padding: 0.2em;
     font-size: .8em;
   }
@@ -137,7 +133,7 @@
   }
 
   .dropdown {
-    width: 75%;
+    width: 74%;
     padding: 0.25em;
     font-size: 0.75em;
   }
@@ -158,15 +154,21 @@
     margin-top: 1.5em;
   }
 
+  .location-input {
+    width: 72%;
+    margin: 0.1em;
+    font-size: 0.75em;
+  }
+
   .dropdown {
-    width: 81%;
-    padding: 0.5em;
+    width: 78%;
     font-size: .7em;
   }
 
   .trip-form button {
     font-size: 1em;
     margin: 0.5em;
-    width: 70%;
+    width: 63%;
+    height: 11%;
   }
 }

--- a/src/Components/NavBar/_navbar.scss
+++ b/src/Components/NavBar/_navbar.scss
@@ -147,6 +147,10 @@ Note: Beware of modifying this element as it can break the animations - you shou
     top: 2.5em;
     right: 2em;
   }
+
+  .menu-item {
+    font-size: 1.75rem;
+  }
 }
 
 @media screen and (max-width: 651px) {

--- a/src/Components/NavBar/mediaQueries.js
+++ b/src/Components/NavBar/mediaQueries.js
@@ -1,9 +1,11 @@
 export default function getDropdownWidth(width) {
-  if (width < 376) {
+  if (width < 321) {
+    return '70%';
+  } else if (width < 376) {
     return '60%';
-  } if (width < 651) {
+  } else if (width < 651) {
     return '50%';
-  } if (width < 1025)  {
+  } else if (width < 1025)  {
     return '35%';
   } else {
     return '20%';

--- a/src/Components/TripComplete/TripComplete.js
+++ b/src/Components/TripComplete/TripComplete.js
@@ -36,7 +36,7 @@ function TripComplete( { modalIsOpen, closeModal } ) {
       >
         <div className='complete-modal'>
             <p className='complete-message'>
-              <span>Your trip is complete! Contact.Name has been notified you made it safely to your destination. </span>
+              <span>Your trip is complete! Contact.Name has been notified that you made it safely to your destination. </span>
             </p>
           <div className='modal-timeout' /></div>
             <NavLink exact to='/'>

--- a/src/Components/TripCompleteMessage/TripCompleteMessage.js
+++ b/src/Components/TripCompleteMessage/TripCompleteMessage.js
@@ -1,33 +1,33 @@
-import Popup from "react-popup";
+import Popup from 'react-popup';
 
 export function TripCompleteMessage(contact, user) {
 
   const sendSms = () => {
     let smsObj = {
       mobile_number: `${contact.phone}`,
-      message: `${user.firstName} has confirmed their trip is completed. Thank you!`,
+      message: `${user.firstName} has confirmed that their trip was completed in time. Thank you!`,
     }
 
     fetch('https://walk-safe-backend.herokuapp.com/sms_messages', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        accepts: "application/json"
+        accepts: 'application/json'
       },
       body: JSON.stringify(smsObj)
     })
-        .then(response => {
-          if(response.status === 201) {
-            Popup.alert(`Trip complete notification successfully sent to ${contact.value}! Thank you for using Walk Safe!`)
-            return response.text();
-          } else {
-            Popup.alert(`Trip complete notification to your contact was unsuccessful, please contact ${contact.value}.`)
-          }
-        })
+      .then(response => {
+        if (response.status === 201) {
+          Popup.alert(`'Trip completed' notification successfully sent to \n${contact.value}. \nThank you for using Walk Safe!`)
+          return response.text();
+        } else {
+          Popup.alert(`'Trip completed' notification was unsuccessful, \nplease contact ${contact.value} directly.`)
+        }
+      })
   }
 
-  return(
-      sendSms()
+  return (
+    sendSms()
   )
 }
 

--- a/src/Components/TripETA/TripETA.js
+++ b/src/Components/TripETA/TripETA.js
@@ -30,6 +30,7 @@ function TripETA( { modalIsOpen, closeModal, eta, tripDetails, contact, userName
   useEffect(() => {
     window.addEventListener("resize", updateDimensions);
     return () => window.removeEventListener("resize", updateDimensions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const updateDimensions = () => {

--- a/src/Components/TripETA/_trip-eta.scss
+++ b/src/Components/TripETA/_trip-eta.scss
@@ -20,6 +20,7 @@
   flex-direction: column;
   font-size: 2rem;
   text-align: center;
+  padding: 0.5em;
 
   span:nth-of-type(1n) {
     font-size: 1.2em;
@@ -48,64 +49,30 @@
   }
 }
 
-@media screen and (max-width: 1050px) {
-  .eta-modal a {
-    width: 55%;
-  }
-}
-
-@media screen and (max-width: 651px) {
-  .eta-modal a {
-    height: 15%;
-    width: 45%;
-    font-size: .75em;
-  }
-  
-  .eta-message span:nth-of-type(1n) {
-    font-size: 0.75em;
-    margin-bottom: 0.7em
-  }
-
-  .eta-message span:nth-of-type(2n) {
-    font-size: 1em;
-    font-weight: 500;
-    margin-bottom: 0.1em;
-  }
-}
-
 @media screen and (max-width: 376px) {
+
   .eta-modal a {
     height: 20%;
-    width: 45%;
-    font-size: .75em;
+    width: 50%;
+  }
+
+  .eta-message {
+    font-size: 1.3rem;
   }
 
   .eta-message span:nth-of-type(1n) {
-    font-size: 0.75em;
-    margin-bottom: 0.7em
+    font-size: 1em;
+    margin:0.4em
   }
 
   .eta-message span:nth-of-type(2n) {
-    font-size: 0.75em;
+    font-size: 1.15em;
     font-weight: 500;
-    margin-bottom: 0.1em;
+    margin: 0.3em;
+  }
+
+  .begin-trip-btn {
+    font-size: 1em;
   }
 }
 
-@media screen and (max-width: 321px) {
-  .eta-modal a {
-    height: 17%;
-    width: 38%;
-  }
-
-  .eta-message span:nth-of-type(1n) {
-    font-size: 0.75em;
-    margin: 0.5em
-  }
-
-  .eta-message span:nth-of-type(2n) {
-    font-size: 0.75em;
-    font-weight: 500;
-    margin: 0.25;
-  }
-}

--- a/src/Components/TripExtendedMessage/TripExtendedMessage.js
+++ b/src/Components/TripExtendedMessage/TripExtendedMessage.js
@@ -6,7 +6,7 @@ export function TripExtendedMessage(user, extension, contact) {
 
     let smsObj = {
       mobile_number: `${contact.phone}`,
-      message: `${user.firstName} has extended their trip by ${extension.label}. Please be on the lookout for the 'trip completed' confirmation message.`,
+      message: `${user.firstName} has extended their trip by ${extension.label}. Please be on the lookout for a 'trip completed' confirmation message.`,
     }
 
     fetch('https://walk-safe-backend.herokuapp.com/sms_messages', {
@@ -17,18 +17,18 @@ export function TripExtendedMessage(user, extension, contact) {
       },
       body: JSON.stringify(smsObj)
     })
-        .then(response => {
-          if(response.status === 201) {
-            Popup.alert(`Trip extended notification successfully sent to ${contact.value}!`)
-            return response.text();
-          } else {
-            Popup.alert(`Trip extended notification to your contact was unsuccessful, please contact ${contact.value}.`)
-          }
-        })
+      .then(response => {
+        if (response.status === 201) {
+          Popup.alert(`'Trip extended' notification successfully sent to ${contact.value}!`)
+          return response.text();
+        } else {
+          Popup.alert(`'Trip extended' notification was unsuccessful, \nplease contact ${contact.value} directly.`)
+        }
+      })
   }
 
-  return(
-      sendSms()
+  return (
+    sendSms()
   )
 }
 

--- a/src/Components/TripNotCompleteMessage/TripNotComplete.js
+++ b/src/Components/TripNotCompleteMessage/TripNotComplete.js
@@ -6,7 +6,7 @@ function TripNotCompleteMessage(user, contact) {
 
     let smsObj = {
       mobile_number: `${contact.phone}`,
-      message: `${user.firstName} has not confirmed their trip is complete. Please contact them now.`,
+      message: `${user.firstName} has not confirmed their completed trip in time. Please contact them immediately.`,
     }
 
     fetch('https://walk-safe-backend.herokuapp.com/sms_messages', {
@@ -19,10 +19,10 @@ function TripNotCompleteMessage(user, contact) {
     })
         .then(response => {
           if(response.status === 201) {
-            Popup.alert(`${contact.value} has been notified you did not complete your trip. Please contact them.`)
+            Popup.alert(`${contact.value} has been notified that you did not complete your trip in time. \nPlease contact them as soon as possible.`)
             return response.text();
           } else {
-            Popup.alert(`Trip not complete notification to your contact was unsuccessful, please contact ${contact.value}.`)
+            Popup.alert(`'Trip not complete' notification was unsuccessful, \nplease contact ${contact.value} directly.`)
           }
         })
   }

--- a/src/Components/TripStartMessage/TripStartMessage.js
+++ b/src/Components/TripStartMessage/TripStartMessage.js
@@ -8,7 +8,7 @@ function TripStartMessage (tripDetails, contact, userName) {
 
     let smsObj = {
       mobile_number: `${contact.phone}`,
-      message: `${userName.firstName} has started a trip from ${textInformation.startPoint} to ${textInformation.endPoint}. ${userName.firstName} is traveling by ${textInformation.travelMode} with an ETA of ${textInformation.eta} minutes. Please be on the look out for a follow up message from ${userName.firstName}`,
+      message: `${userName.firstName} has started a trip from ${textInformation.startPoint} to ${textInformation.endPoint}.  ${userName.firstName} is traveling by ${textInformation.travelMode} with an ETA of ${textInformation.eta} minutes.  Please be on the lookout for a follow-up message from ${userName.firstName}.`,
     }
 
     fetch('https://walk-safe-backend.herokuapp.com/sms_messages', {
@@ -19,18 +19,18 @@ function TripStartMessage (tripDetails, contact, userName) {
       },
       body: JSON.stringify(smsObj)
     })
-        .then(response => {
-          if(response.status === 201) {
-            Popup.alert(`Start trip notification successfully sent to ${contact.value}!`)
-            return response.text();
+      .then(response => {
+        if(response.status === 201) {
+          Popup.alert(`'Trip started' notification successfully sent to \n${contact.value}.`)
+          return response.text();
         } else {
-            Popup.alert(`Start trip notification to ${contact.value} was unsuccessful, please restart your trip and try again.`)
-          }
-  })
+          Popup.alert(`'Trip started' notification sent to ${contact.value} was unsuccessful, \nplease restart your trip and try again.`)
+        }
+      })
   }
 
-return(
-      sendSms()
+  return (
+    sendSms()
   )
 }
 

--- a/src/assets/travelModeData.js
+++ b/src/assets/travelModeData.js
@@ -1,6 +1,6 @@
 const transportOptions = [
-  {value: 'driving', label: 'Driving'},
   {value: 'walking', label: 'Walking'},
+  {value: 'driving', label: 'Driving'},
   {value: 'bicycling', label: 'Bicycling'}
 ]
 

--- a/src/assets/travelModeData.js
+++ b/src/assets/travelModeData.js
@@ -1,7 +1,7 @@
 const transportOptions = [
   {value: 'walking', label: 'Walking'},
-  {value: 'driving', label: 'Driving'},
-  {value: 'bicycling', label: 'Bicycling'}
+  {value: 'bicycling', label: 'Bicycling'},
+  {value: 'driving', label: 'Driving'}
 ]
 
 export default transportOptions;


### PR DESCRIPTION
## Type of Change
- [x] JSX
- [ ] HTML
- [ ] JavaScript
- [x] CSS
- [ ] React
- [ ] React Router
- [ ] Cypress
- [ ] Apollo
- [ ] GraphQL
- [ ] Twilio API
- [x] Refactor/Fix Bugs

## Please describe the change made
modal/popup media query fix

## Please give a short description of the changes that were made below

- Fix:
- Resized popups and added media query
- Refactored all modal media queries in both CSS and JSX
- Eliminated console warnings
- Identified the cause of the 'memory leak' console error: `line 80 in CurrentTrip`, which reassigns setTripEnded() inside of that useEffect() hook.  It's a problem, I think, because a child component is setting the state of a parent component, which it then depends on for its own conditional functionality.

## How has this been tested?
- [x] In Browser
- [x] In Console
- [ ] Cypress
- [ ] Postman
